### PR TITLE
Fix type error when counting unlocked skills

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -396,7 +396,7 @@ async function sendMe(ctx: MyContext) {
   }
   const lurking = p.skills.lurking ?? 0;
   const moving = p.skills.moving ?? 0;
-  const skillsUnlocked = (Math.floor(lurking) >= 1) + (Math.floor(moving) >= 1);
+  const skillsUnlocked = Number(Math.floor(lurking) >= 1) + Number(Math.floor(moving) >= 1);
 
   const lines: string[] = [];
   lines.push(ctx.t("me-base", {


### PR DESCRIPTION
## Summary
- fix the boolean arithmetic used to count unlocked skills in the profile summary so TypeScript can compile the build
- ensure the count logic explicitly converts unlocked flags to numbers to avoid future regressions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df690742a0832988c2c1c9cf38935e